### PR TITLE
Feature/#3-vendor-entity: 업체(Vendor) 도메인 엔티티 정의 및 테이블 설계

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ apply from: 'gradle/database.gradle'
 apply from: 'gradle/docs.gradle'
 apply from: 'gradle/test.gradle'
 apply from: 'gradle/util.gradle'
+apply from: 'gradle/security.gradle'
 
 tasks.register('copyConfig', Copy) {
 	from 'config/src/main/resources'

--- a/gradle/security.gradle
+++ b/gradle/security.gradle
@@ -1,0 +1,14 @@
+dependencies {
+
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // OAuth2 Client
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.security:spring-security-oauth2-client'
+
+    // JWT (JJWT)
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+}

--- a/src/main/java/com/wedit/backend/WeditBackendApplication.java
+++ b/src/main/java/com/wedit/backend/WeditBackendApplication.java
@@ -2,7 +2,9 @@ package com.wedit.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class WeditBackendApplication {
 

--- a/src/main/java/com/wedit/backend/api/agency/entity/Agency.java
+++ b/src/main/java/com/wedit/backend/api/agency/entity/Agency.java
@@ -1,0 +1,34 @@
+package com.wedit.backend.api.agency.entity;
+
+import com.wedit.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "agencies")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Agency extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(nullable = false)
+    private boolean isActive = true;
+
+    @Builder
+    public Agency(String name) {
+        this.name = name;
+    }
+
+    private void deactivate() {
+        this.isActive = false;
+    }
+}

--- a/src/main/java/com/wedit/backend/api/agency/entity/Agency.java
+++ b/src/main/java/com/wedit/backend/api/agency/entity/Agency.java
@@ -26,9 +26,10 @@ public class Agency extends BaseTimeEntity {
     @Builder
     public Agency(String name) {
         this.name = name;
+        this.isActive = true;
     }
 
-    private void deactivate() {
+    public void deactivate() {
         this.isActive = false;
     }
 }

--- a/src/main/java/com/wedit/backend/api/member/entity/Member.java
+++ b/src/main/java/com/wedit/backend/api/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.wedit.backend.api.member.entity;
 
+import com.wedit.backend.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder(toBuilder = true)
 @EqualsAndHashCode(of = "id")
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/wedit/backend/api/product/entity/ItemGroup.java
+++ b/src/main/java/com/wedit/backend/api/product/entity/ItemGroup.java
@@ -1,0 +1,55 @@
+package com.wedit.backend.api.product.entity;
+
+import com.wedit.backend.api.vendor.entity.Vendor;
+import com.wedit.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "item_groups")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemGroup extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "vendor_id", nullable = false)
+    private Vendor vendor;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    private Long cachedMinPrice;
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    @Builder
+    public ItemGroup(Vendor vendor, String name, String description) {
+        this.vendor = vendor;
+        this.name = name;
+        this.description = description;
+        this.cachedMinPrice = 0L;
+    }
+
+    public void assignVendor(Vendor vendor) {
+        this.vendor = vendor;
+    }
+
+    public void updateCachedMinPrice(Long newMinPrice) {
+        this.cachedMinPrice = newMinPrice;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+}

--- a/src/main/java/com/wedit/backend/api/product/entity/OptionDetail.java
+++ b/src/main/java/com/wedit/backend/api/product/entity/OptionDetail.java
@@ -1,0 +1,61 @@
+package com.wedit.backend.api.product.entity;
+
+import com.wedit.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "option_details")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OptionDetail extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_group_id", nullable = false)
+    private OptionGroup optionGroup;
+
+    @Column(nullable = false)
+    private String name;                // 옵션 이름
+
+    @Column(nullable = false)
+    private Long price;                 // 추가 가격
+
+    // 수량 기반 옵션 필드
+    private String unit;                // 단순 1회성이면 null (장, 벌, 시간 등)
+    private Integer maxCount;           // 최대 선택 가능 수량 (제한 없으면 null)
+
+    @Column(nullable = false)
+    private boolean isSoldOut = false;  // 품절 여부
+
+    @Column(nullable = false)
+    private Integer ordering;
+
+    @Builder
+    public OptionDetail(String name, Long price, String unit, Integer maxCount, Integer ordering) {
+        this.name = name;
+        this.price = price != null ? price : 0L;
+        this.unit = unit;
+        this.maxCount = maxCount;
+        this.ordering = ordering != null ? ordering : 0;
+    }
+
+    public void assignOptionGroup(OptionGroup optionGroup) {
+        this.optionGroup = optionGroup;
+    }
+
+    public void toggleSoldOut() {
+        this.isSoldOut = !this.isSoldOut;
+    }
+
+    // 견적서 계산 시 수량을 곱해야 하는 옵션인지 판단하기 위한 메서드
+    public boolean isQuantityBased() {
+        return this.unit != null;
+    }
+}

--- a/src/main/java/com/wedit/backend/api/product/entity/OptionGroup.java
+++ b/src/main/java/com/wedit/backend/api/product/entity/OptionGroup.java
@@ -1,0 +1,64 @@
+package com.wedit.backend.api.product.entity;
+
+import com.wedit.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "option_groups")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OptionGroup extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(nullable = false)
+    private String name;                // 옵션 그룹 이름
+
+    @Column(nullable = false)
+    private boolean isMandatory;        // 필수 선택 여부
+
+    private Integer minSelectCount;     // 최소 선택 개수 (필수면 1)
+    private Integer maxSelectCount;     // 최대 선택 개수 (라디오면 1, 이외 99)
+
+    @Column(nullable = false)
+    private Integer ordering;           // 정렬 순서
+
+
+    @OneToMany(mappedBy = "optionGorup", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("ordering ASC")
+    private List<OptionDetail> optionDetails = new ArrayList<>();
+
+    @Builder
+    public OptionGroup(String name, boolean isMandatory, Integer minSelectCount, Integer maxSelectCount,
+                    Integer ordering) {
+        this.name = name;
+        this.isMandatory = isMandatory;
+        this.minSelectCount = minSelectCount != null ? minSelectCount : (isMandatory ? 1 : 0);
+        this.maxSelectCount = maxSelectCount != null ? maxSelectCount : 1;
+        this.ordering = ordering != null ? ordering : 0;
+        this.optionDetails = new ArrayList<>();
+    }
+
+    public void assignProduct(Product product) {
+        this.product = product;
+    }
+
+    // 옵션 상세 추가
+    public void addOptionDetail(OptionDetail detail) {
+        this.optionDetails.add(detail);
+        detail.assignOptionGroup(this);
+    }
+}

--- a/src/main/java/com/wedit/backend/api/product/entity/OptionGroup.java
+++ b/src/main/java/com/wedit/backend/api/product/entity/OptionGroup.java
@@ -37,9 +37,9 @@ public class OptionGroup extends BaseTimeEntity {
     private Integer ordering;           // 정렬 순서
 
 
-    @OneToMany(mappedBy = "optionGorup", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "optionGroup", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("ordering ASC")
-    private List<OptionDetail> optionDetails = new ArrayList<>();
+    private List<OptionDetail> optionDetails;
 
     @Builder
     public OptionGroup(String name, boolean isMandatory, Integer minSelectCount, Integer maxSelectCount,

--- a/src/main/java/com/wedit/backend/api/product/entity/Product.java
+++ b/src/main/java/com/wedit/backend/api/product/entity/Product.java
@@ -1,0 +1,85 @@
+package com.wedit.backend.api.product.entity;
+
+import com.wedit.backend.api.agency.entity.Agency;
+import com.wedit.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "products")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_group_id", nullable = false)
+    private ItemGroup itemGroup;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agency_id", nullable = false)
+    private Agency agency;
+
+    @Column(nullable = false)
+    private String name;            // 상품 이름
+
+    @Column(nullable = false)
+    private Long basePrice = 0L;    // 기본 가격 0원 시작
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private List<String> tags = new ArrayList<>();  // UI 및 검색용 태그 (JSON)
+
+    @Column(nullable = false)
+    private boolean isVisible = false;  // 노출 제어 필드 (true: UI 노출)
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("ordering ASC")
+    private List<OptionGroup> optionGroups = new ArrayList<>();
+
+    @Builder
+    public Product(ItemGroup itemGroup, Agency agency, String name, Long basePrice,
+                List<String> tags) {
+        this.itemGroup = itemGroup;
+        this.agency = agency;
+        this.name = name;
+        this.basePrice = basePrice != null ? basePrice : 0L;
+        this.tags = tags != null ? tags : new ArrayList<>();
+        this.isVisible = false;   // 최초 등록 시 임시저장 상태
+        this.isDeleted = false;
+        this.optionGroups = new ArrayList<>();
+    }
+
+    public void publish() {
+        this.isVisible = true;
+    }
+
+    public void hide() {
+        this.isVisible = false;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+        this.isVisible = false;
+    }
+
+    // 옵션 그룹 추가
+    public void addOptionGroup(OptionGroup optionGroup) {
+        this.optionGroups.add(optionGroup);
+        optionGroup.assignProduct(this);
+    }
+}

--- a/src/main/java/com/wedit/backend/api/vendor/entity/Vendor.java
+++ b/src/main/java/com/wedit/backend/api/vendor/entity/Vendor.java
@@ -1,0 +1,92 @@
+package com.wedit.backend.api.vendor.entity;
+
+import com.wedit.backend.api.product.entity.ItemGroup;
+import com.wedit.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "vendors")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Vendor extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;            // 업체 이름
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private VendorCategory category;    // 업종 (웨딩홀/드레스/메이크업/스튜디오)
+
+    @Column(nullable = false)
+    private String region;          // 소속 지역
+
+    @Column(nullable = false)
+    private String fullAddress;     // 업체 전체 주소 (도로명 또는 지번)
+
+    private String addressDetail;   // 업체 상세 주소 (3층, 201호 등)
+
+    private String contactInfo;     // 업체 연락처
+
+    private Double latitude;        // 위도
+
+    private Double longitude;       // 경도
+
+    private String kakaoMapUrl;     // 카카오맵 URL
+
+    @Column(columnDefinition = "TEXT")
+    private String description;     // 업체 소개
+
+    @Column(nullable = false)
+    private boolean isActive = true;
+
+    @OneToMany(mappedBy = "vendor", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ItemGroup> itemGroups = new ArrayList<>();
+
+    @OneToMany(mappedBy = "vendor", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("ordering ASC")
+    private List<VendorMedia> mediaList = new ArrayList<>();
+
+    @Builder
+    public Vendor(String name, VendorCategory category, String region, String fullAddress,
+                  String addressDetail, String contactInfo, Double latitude, Double longitude,
+                  String kakaoMapUrl, String description) {
+        this.name = name;
+        this.category = category;
+        this.region = region;
+        this.fullAddress = fullAddress;
+        this.addressDetail = addressDetail;
+        this.contactInfo = contactInfo;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.kakaoMapUrl = kakaoMapUrl;
+        this.description = description;
+        this.isActive = true;
+        this.itemGroups = new ArrayList<>();
+        this.mediaList = new ArrayList<>();
+    }
+
+    public void addItemGroup(ItemGroup itemGroup) {
+        itemGroups.add(itemGroup);
+        itemGroup.assignVendor(this);
+    }
+
+    public void addMedia(VendorMedia media) {
+        this.mediaList.add(media);
+        media.assignVendor(this);
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+}

--- a/src/main/java/com/wedit/backend/api/vendor/entity/VendorCategory.java
+++ b/src/main/java/com/wedit/backend/api/vendor/entity/VendorCategory.java
@@ -1,0 +1,8 @@
+package com.wedit.backend.api.vendor.entity;
+
+public enum VendorCategory {
+    STUDIO,
+    MAKEUP,
+    DRESS,
+    WEDDING_HALL
+}

--- a/src/main/java/com/wedit/backend/api/vendor/entity/VendorMedia.java
+++ b/src/main/java/com/wedit/backend/api/vendor/entity/VendorMedia.java
@@ -1,0 +1,30 @@
+package com.wedit.backend.api.vendor.entity;
+
+import com.wedit.backend.common.entity.BaseMedia;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@Table(name = "vendor_media")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class VendorMedia extends BaseMedia {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "vendor_id", nullable = false)
+    private Vendor vendor;
+
+    private boolean isThumbnail;
+
+    public void assignVendor(Vendor vendor) {
+        this.vendor = vendor;
+    }
+}

--- a/src/main/java/com/wedit/backend/api/vendor/entity/VendorMedia.java
+++ b/src/main/java/com/wedit/backend/api/vendor/entity/VendorMedia.java
@@ -3,6 +3,7 @@ package com.wedit.backend.api.vendor.entity;
 import com.wedit.backend.common.entity.BaseMedia;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -11,7 +12,6 @@ import lombok.experimental.SuperBuilder;
 @Entity
 @Table(name = "vendor_media")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SuperBuilder
 public class VendorMedia extends BaseMedia {
 
     @Id
@@ -23,6 +23,13 @@ public class VendorMedia extends BaseMedia {
     private Vendor vendor;
 
     private boolean isThumbnail;
+
+    @Builder // 클래스가 아닌 생성자 레벨에 붙임
+    public VendorMedia(Vendor vendor, String url, Integer ordering, boolean isThumbnail) {
+        super(url, ordering);
+        this.vendor = vendor;
+        this.isThumbnail = isThumbnail;
+    }
 
     public void assignVendor(Vendor vendor) {
         this.vendor = vendor;

--- a/src/main/java/com/wedit/backend/common/entity/BaseMedia.java
+++ b/src/main/java/com/wedit/backend/common/entity/BaseMedia.java
@@ -1,0 +1,26 @@
+package com.wedit.backend.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public abstract class BaseMedia extends BaseTimeEntity {
+
+    @Column(nullable = false)
+    private String url;
+
+    @Column(nullable = false)
+    private Integer ordering;
+
+    protected BaseMedia(String url, Integer ordering) {
+        this.url = url;
+        this.ordering = ordering != null ? ordering : 0;
+    }
+}

--- a/src/main/java/com/wedit/backend/common/entity/BaseMedia.java
+++ b/src/main/java/com/wedit/backend/common/entity/BaseMedia.java
@@ -5,12 +5,10 @@ import jakarta.persistence.MappedSuperclass;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @MappedSuperclass
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SuperBuilder
 public abstract class BaseMedia extends BaseTimeEntity {
 
     @Column(nullable = false)

--- a/src/main/java/com/wedit/backend/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/wedit/backend/common/entity/BaseTimeEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;

--- a/src/main/java/com/wedit/backend/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/wedit/backend/common/entity/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.wedit.backend.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected LocalDateTime updatedAt;
+}

--- a/src/main/java/com/wedit/backend/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/wedit/backend/common/entity/BaseTimeEntity.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;


### PR DESCRIPTION
## Related Issue
- close #3 

## Why - 해결하려는 문제가 무엇인가요?

- 업체 및 상품 도메인 엔티티 설계와 정의

- 검색과 필터링, 견적서, 청첩장 등에 쓰일 업체 및 상품 도메인 엔티티 정의

## What - 무엇이 변경됐나요?

### 신규 엔티티
| 엔티티 | 테이블 | 설명 |
|---|---|---|
| `Vendor` | `vendors` | 스튜디오/드레스샵/메이크업샵/웨딩홀 업체 |
| `VendorMedia` | `vendor_media` | 업체 갤러리 이미지 |
| `Agency` | `agencies` | 다이렉트컴즈, 베리굿 등 대행사 |
| `ItemGroup` | `item_groups` | 업체가 판매하는 상품 묶음 (최저가 캐싱 포함) |
| `Product` | `products` | 대행사별 실제 판매 상품 |
| `OptionGroup` | `option_groups` | 상품의 옵션 그룹 (필수/선택 구분) |
| `OptionDetail` | `option_details` | 각 옵션의 구체적인 항목 및 가격 |

### 공통 추상 클래스
- `BaseMedia` (`@MappedSuperclass`): 도메인별 미디어 엔티티가 상속하는 공통 부모 클래스 (`url`, `ordering` 필드)

## How - 어떻게 해결했나요?

### 의존 관계 요약
`Vendor -> ItemGroup -> Product -> OptionGroup -> OptionDetail`
`Vendor -> VendorMedia`
`Agency -> Product`

### 핵심 설계 결정 사항

**1. 메이크업 직급별 기본가 처리**

메이크업 업체 특성상 실장/부원장/원장 등 직급에 따라 기본 가격이 달라지는 경우,
별도의 `Product`를 쪼개지 않고 단일 `Product`에 `isMandatory = true`인
`OptionGroup`을 만들어 처리.

Product (basePrice = 0)
└── OptionGroup "직급 선택 (필수)" [isMandatory = true, maxSelectCount = 1]
├── OptionDetail "실장급" (+605,000)
├── OptionDetail "부원장급" (+715,000)
└── OptionDetail "원장급" (+825,000)

**2. 수량 기반 옵션 처리**

"앨범 페이지 추가 (1장당 33,000원)", "드레스 추가 (1벌당 110,000원)" 처럼
수량을 곱해야 하는 옵션을 위해 `OptionDetail`에 `unit`, `maxCount` 필드를 추가.
- `unit`이 `null`이면 단순 1회성 선택 옵션
- `unit`이 존재하면 수량 기반 옵션으로, 견적서 계산 시 `price × quantity`로 계산.

**3. 도메인별 전용 미디어 엔티티**

단일 `Media` 테이블에 `ownerDomain/ownerId`로 다형성을 구현하는 방식 대신,
도메인마다 전용 미디어 엔티티를 두는 방식을 채택.
- FK를 통한 **DB 레벨의 참조 무결성 보장**
- `JOIN FETCH`를 통한 **N+1 문제 예방**
- `Cascade.ALL + orphanRemoval = true`로 **부모-자식 생명주기 자동 관리**

**4. Soft Delete 적용**
`ItemGroup`, `Product`는 `isDeleted` 필드로 Soft Delete를 적용.
실제 데이터를 삭제하지 않아, 향후 견적서에서 참조 중인 상품의 데이터 정합성을 보호.


**5. 생성자 레벨 `@Builder` 유지**
클래스 레벨 `@Builder`의 경우 `@AllArgsConstructor` 강제 생성으로 인한
캡슐화 침해 문제가 있어, 생성자 레벨 `@Builder`를 유지.
컬렉션 필드는 생성자 내부에서 명시적으로 `new ArrayList<>()`로 초기화.

## 기타 코멘트

- `ProductMedia`(상품 이미지), `InvitationMedia`(청첩장 이미지/비디오/오디오) 등
  나머지 도메인별 미디어 엔티티는 해당 도메인 구현 시 동일 패턴으로 추가 예정.