### PR TITLE
Feature/#2-s3: AWS S3 인프라 계층 분리 및 Presigned URL 발급 API 구현

### DIFF
--- a/gradle/util.gradle
+++ b/gradle/util.gradle
@@ -9,6 +9,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    // AWS SDK for S3
-
+    // AWS SDK for S3 (BOM 지정)
+    implementation platform('software.amazon.awssdk:bom:2.41.34')
+    implementation 'software.amazon.awssdk:s3'
 }

--- a/src/main/java/com/wedit/backend/api/aws/controller/AwsS3Controller.java
+++ b/src/main/java/com/wedit/backend/api/aws/controller/AwsS3Controller.java
@@ -1,0 +1,36 @@
+package com.wedit.backend.api.aws.controller;
+
+import com.wedit.backend.api.aws.dto.AwsS3RequestDTO;
+import com.wedit.backend.api.aws.dto.AwsS3ResponseDTO;
+import com.wedit.backend.api.aws.service.AwsS3Service;
+import com.wedit.backend.common.response.ApiResponse;
+import com.wedit.backend.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "AWS S3", description = "AWS S3 미디어 API 입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/s3")
+public class AwsS3Controller {
+
+    private final AwsS3Service awsS3Service;
+
+    @Operation(summary = "Presigned URL 단건 발급",
+            description = "이미지 업로드를 위한 AWS S3 Presigned URL를 발급합니다. 클라이언트는 응답받은 URL로 PUT 요청을 보내 이미지를 업로드해야 합니다.")
+    @PostMapping("/presigned-url")
+    public ResponseEntity<ApiResponse<AwsS3ResponseDTO>> generatePresignedUrl(
+            @Valid @RequestBody AwsS3RequestDTO requestDTO
+    ) {
+        AwsS3ResponseDTO responseDTO = awsS3Service.generatePresignedUrl(requestDTO);
+
+        return ApiResponse.success(SuccessStatus.AWS_S3_PRESIGNED_URL_SUCCESS, responseDTO);
+    }
+}

--- a/src/main/java/com/wedit/backend/api/aws/dto/AwsS3RequestDTO.java
+++ b/src/main/java/com/wedit/backend/api/aws/dto/AwsS3RequestDTO.java
@@ -1,0 +1,23 @@
+package com.wedit.backend.api.aws.dto;
+
+import com.wedit.backend.api.aws.enums.AwsS3Directory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "AWS S3 Presigned URL 발급 요청 DTO")
+public record AwsS3RequestDTO(
+
+        @NotNull(message = "디렉토리명은 필수입니다. (vendors, products)")
+        AwsS3Directory directory,   // vendors, products
+
+        @NotBlank(message = "원본 파일명은 필수입니다.")
+        String originalFileName,    // 파일 원본 이름
+
+        @NotBlank(message = "Content-Type은 필수입니다. (image/jpeg)")
+        String contentType         // MIME 타입
+
+//        @NotNull(message = "Content-Length는 필수입니다.")
+//        @Positive(message = "Content-Length는 음수일 수 없습니다.")
+//        Long contentLength          // 컨텐츠 크기
+) { }

--- a/src/main/java/com/wedit/backend/api/aws/dto/AwsS3ResponseDTO.java
+++ b/src/main/java/com/wedit/backend/api/aws/dto/AwsS3ResponseDTO.java
@@ -1,0 +1,11 @@
+package com.wedit.backend.api.aws.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "AWS S3 Presigned URL 발급 응답 DTO")
+public record AwsS3ResponseDTO(
+        String presignedUrl,    // 클라이언트가 PUT 요청할 S3 URL
+        String fileKey,         // DB 저장용 S3 객체 키
+        String cloudFrontUrl    // 업로드 완료 후 조회용 URL
+) {
+}

--- a/src/main/java/com/wedit/backend/api/aws/enums/AwsS3Directory.java
+++ b/src/main/java/com/wedit/backend/api/aws/enums/AwsS3Directory.java
@@ -1,0 +1,16 @@
+package com.wedit.backend.api.aws.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AwsS3Directory {
+
+    VENDORS("vendors"),
+    PRODUCTS("products"),
+
+    ;
+
+    private final String path;
+}

--- a/src/main/java/com/wedit/backend/api/aws/service/AwsS3Service.java
+++ b/src/main/java/com/wedit/backend/api/aws/service/AwsS3Service.java
@@ -1,0 +1,105 @@
+package com.wedit.backend.api.aws.service;
+
+import com.wedit.backend.api.aws.dto.AwsS3RequestDTO;
+import com.wedit.backend.api.aws.dto.AwsS3ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AwsS3Service {
+
+    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${cloud.aws.s3.presign.expiration-minutes}")
+    private Integer expirationMinutes;
+
+    @Value("${cloud.aws.cloudfront.url}")
+    private String cloudFrontBaseUrl;
+
+
+    // Presigned URL 발급
+    public AwsS3ResponseDTO generatePresignedUrl(AwsS3RequestDTO requestDTO) {
+
+        String fileKey = buildFileKey(
+                requestDTO.directory().getPath(),
+                requestDTO.originalFileName()
+        );
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileKey)
+                .contentType(requestDTO.contentType())
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .putObjectRequest(putObjectRequest)
+                .signatureDuration(Duration.ofMinutes(expirationMinutes))
+                .build();
+
+        String presignedUrl = s3Presigner.presignPutObject(presignRequest).url().toString();
+
+        String cloudFrontUrl = toCloudFrontUrl(fileKey);
+
+        log.info("[S3] Presigned URL 발급 - directory: {}, fileKey: {}",
+                requestDTO.directory(), fileKey);
+
+        return new AwsS3ResponseDTO(presignedUrl, fileKey, cloudFrontUrl);
+    }
+
+    // S3 파일 단건 삭제
+    public void deleteFile(String fileKey) {
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(fileKey)
+                    .build());
+            log.info("[S3] 파일 삭제 성공 - fileKey: {}", fileKey);
+        } catch (Exception e) {
+            log.error("[S3] 파일 삭제 실패 - fileKey: {}", fileKey, e);
+        }
+    }
+
+    // https://cloudfront-domain/vendors/{UUID}.jpg
+    public String toCloudFrontUrl(String fileKey) {
+
+        if (fileKey == null || fileKey.isBlank()) {
+            return null;
+        }
+
+        return cloudFrontBaseUrl + "/" + fileKey;
+    }
+
+    // vendors/{UUID}.jpg
+    private String buildFileKey(String directory, String originalFileName) {
+
+        String extension = extractExtension(originalFileName);
+        return directory + "/" + UUID.randomUUID() + extension;
+    }
+
+    // photo.jpg -> .jpg
+    private String extractExtension(String fileName) {
+
+        int dotIndex = fileName.lastIndexOf(".");
+        if (dotIndex == -1 || dotIndex == fileName.length() - 1) {
+            return "";
+        }
+
+        return fileName.substring(dotIndex).toLowerCase();
+    }
+}

--- a/src/main/java/com/wedit/backend/api/product/entity/Product.java
+++ b/src/main/java/com/wedit/backend/api/product/entity/Product.java
@@ -49,7 +49,11 @@ public class Product extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("ordering ASC")
-    private List<OptionGroup> optionGroups = new ArrayList<>();
+    private List<OptionGroup> optionGroups; // 상품 옵션 그룹
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("ordering ASC")
+    private List<ProductMedia> mediaList;   // 상품 이미지들
 
     @Builder
     public Product(ItemGroup itemGroup, Agency agency, String name, Long basePrice,
@@ -62,6 +66,7 @@ public class Product extends BaseTimeEntity {
         this.isVisible = false;   // 최초 등록 시 임시저장 상태
         this.isDeleted = false;
         this.optionGroups = new ArrayList<>();
+        this.mediaList = new ArrayList<>();
     }
 
     public void publish() {
@@ -81,5 +86,10 @@ public class Product extends BaseTimeEntity {
     public void addOptionGroup(OptionGroup optionGroup) {
         this.optionGroups.add(optionGroup);
         optionGroup.assignProduct(this);
+    }
+
+    public void addMedia(ProductMedia media) {
+        this.mediaList.add(media);
+        media.assignProduct(this);
     }
 }

--- a/src/main/java/com/wedit/backend/api/product/entity/ProductMedia.java
+++ b/src/main/java/com/wedit/backend/api/product/entity/ProductMedia.java
@@ -1,0 +1,33 @@
+package com.wedit.backend.api.product.entity;
+
+import com.wedit.backend.common.entity.BaseMedia;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "product_media")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductMedia extends BaseMedia {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Builder
+    public ProductMedia(Product product, String fileKey, String url, Integer ordering) {
+        super(url, fileKey, ordering);
+        this.product = product;
+    }
+
+    public void assignProduct(Product product) {
+        this.product = product;
+    }
+}

--- a/src/main/java/com/wedit/backend/api/product/repository/ProductMediaRepository.java
+++ b/src/main/java/com/wedit/backend/api/product/repository/ProductMediaRepository.java
@@ -1,0 +1,13 @@
+package com.wedit.backend.api.product.repository;
+
+import com.wedit.backend.api.product.entity.ProductMedia;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProductMediaRepository extends JpaRepository<ProductMedia, Long> {
+
+    List<ProductMedia> findByProductId(Long productId);
+}

--- a/src/main/java/com/wedit/backend/api/vendor/entity/Vendor.java
+++ b/src/main/java/com/wedit/backend/api/vendor/entity/Vendor.java
@@ -38,39 +38,31 @@ public class Vendor extends BaseTimeEntity {
 
     private String contactInfo;     // 업체 연락처
 
-    private Double latitude;        // 위도
-
-    private Double longitude;       // 경도
-
     private String kakaoMapUrl;     // 카카오맵 URL
 
-    @Column(columnDefinition = "TEXT")
-    private String description;     // 업체 소개
+    private String vendorUrl;     // 업체 URL
 
     @Column(nullable = false)
     private boolean isActive = true;
 
     @OneToMany(mappedBy = "vendor", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ItemGroup> itemGroups = new ArrayList<>();
+    private List<ItemGroup> itemGroups;
 
     @OneToMany(mappedBy = "vendor", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("ordering ASC")
-    private List<VendorMedia> mediaList = new ArrayList<>();
+    private List<VendorMedia> mediaList;
 
     @Builder
     public Vendor(String name, VendorCategory category, String region, String fullAddress,
-                  String addressDetail, String contactInfo, Double latitude, Double longitude,
-                  String kakaoMapUrl, String description) {
+                  String addressDetail, String contactInfo, String kakaoMapUrl, String vendorUrl) {
         this.name = name;
         this.category = category;
         this.region = region;
         this.fullAddress = fullAddress;
         this.addressDetail = addressDetail;
         this.contactInfo = contactInfo;
-        this.latitude = latitude;
-        this.longitude = longitude;
         this.kakaoMapUrl = kakaoMapUrl;
-        this.description = description;
+        this.vendorUrl = vendorUrl;
         this.isActive = true;
         this.itemGroups = new ArrayList<>();
         this.mediaList = new ArrayList<>();

--- a/src/main/java/com/wedit/backend/api/vendor/entity/VendorMedia.java
+++ b/src/main/java/com/wedit/backend/api/vendor/entity/VendorMedia.java
@@ -6,7 +6,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @Entity
@@ -25,8 +24,8 @@ public class VendorMedia extends BaseMedia {
     private boolean isThumbnail;
 
     @Builder // 클래스가 아닌 생성자 레벨에 붙임
-    public VendorMedia(Vendor vendor, String url, Integer ordering, boolean isThumbnail) {
-        super(url, ordering);
+    public VendorMedia(Vendor vendor, String url, String fileKey, Integer ordering, boolean isThumbnail) {
+        super(url, fileKey, ordering);
         this.vendor = vendor;
         this.isThumbnail = isThumbnail;
     }

--- a/src/main/java/com/wedit/backend/api/vendor/repository/VendorMediaRepository.java
+++ b/src/main/java/com/wedit/backend/api/vendor/repository/VendorMediaRepository.java
@@ -1,0 +1,16 @@
+package com.wedit.backend.api.vendor.repository;
+
+import com.wedit.backend.api.vendor.entity.VendorMedia;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface VendorMediaRepository extends JpaRepository<VendorMedia, Long> {
+
+    List<VendorMedia> findByVendorId(Long vendorId);
+
+    Optional<VendorMedia> findByVendorIdAndIsThumbnailTrue(Long vendorId);
+}

--- a/src/main/java/com/wedit/backend/api/vendor/repository/VendorRepository.java
+++ b/src/main/java/com/wedit/backend/api/vendor/repository/VendorRepository.java
@@ -1,0 +1,10 @@
+package com.wedit.backend.api.vendor.repository;
+
+import com.wedit.backend.api.vendor.entity.Vendor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VendorRepository extends JpaRepository<Vendor, Long> {
+
+}

--- a/src/main/java/com/wedit/backend/common/config/aws/AwsS3Config.java
+++ b/src/main/java/com/wedit/backend/common/config/aws/AwsS3Config.java
@@ -12,12 +12,12 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 public class AwsS3Config {
 
     @Value("${cloud.aws.region.static}")
-    private Region region;
+    private String region;
 
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
-                .region(region)
+                .region(Region.of(region))
                 .credentialsProvider(DefaultCredentialsProvider.builder().build())
                 .build();
     }
@@ -25,7 +25,7 @@ public class AwsS3Config {
     @Bean
     public S3Presigner s3Presigner() {
         return S3Presigner.builder()
-                .region(region)
+                .region(Region.of(region))
                 .credentialsProvider(DefaultCredentialsProvider.builder().build())
                 .build();
     }

--- a/src/main/java/com/wedit/backend/common/config/aws/AwsS3Config.java
+++ b/src/main/java/com/wedit/backend/common/config/aws/AwsS3Config.java
@@ -1,0 +1,32 @@
+package com.wedit.backend.common.config.aws;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.region.static}")
+    private Region region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(region)
+                .credentialsProvider(DefaultCredentialsProvider.builder().build())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(region)
+                .credentialsProvider(DefaultCredentialsProvider.builder().build())
+                .build();
+    }
+}

--- a/src/main/java/com/wedit/backend/common/entity/BaseMedia.java
+++ b/src/main/java/com/wedit/backend/common/entity/BaseMedia.java
@@ -15,10 +15,18 @@ public abstract class BaseMedia extends BaseTimeEntity {
     private String url;
 
     @Column(nullable = false)
+    private String fileKey;
+
+    @Column(nullable = false)
     private Integer ordering;
 
-    protected BaseMedia(String url, Integer ordering) {
+    protected BaseMedia(String url, String fileKey, Integer ordering) {
         this.url = url;
+        this.fileKey = fileKey;
         this.ordering = ordering != null ? ordering : 0;
+    }
+
+    public void updateOrdering(int ordering) {
+        this.ordering = ordering;
     }
 }

--- a/src/main/java/com/wedit/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/wedit/backend/common/response/ErrorStatus.java
@@ -20,6 +20,9 @@ public enum ErrorStatus {
 
     /// 404 NOT FOUND
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    NOT_FOUND_VENDOR(HttpStatus.NOT_FOUND, "해당 업체를 찾을 수 없습니다."),
+    NOT_FOUND_PRODUCT(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다."),
+    NOT_FOUND_MEDIA(HttpStatus.NOT_FOUND, "해당 미디어를 찾을 수 없습니다."),
 
     /// 409 CONFLICT
     CONFLICT_DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "중복된 리소스가 존재합니다."),

--- a/src/main/java/com/wedit/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/wedit/backend/common/response/SuccessStatus.java
@@ -11,15 +11,18 @@ public enum SuccessStatus {
 
     /// 200 OK
     FORM_LOGIN_SUCCESS(HttpStatus.OK, "폼 로그인 성공"),
+    MEMBER_WITHDRAW_SUCCESS(HttpStatus.OK, "회원탈퇴 성공"),
+    TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
+    MEDIA_LIST_SUCCESS(HttpStatus.OK, "미디어 목록 조회 성공"),
+    MEDIA_UPDATE_SUCCESS(HttpStatus.OK, "미디어 수정 성공"),
+    AWS_S3_PRESIGNED_URL_SUCCESS(HttpStatus.OK, "S3 Presigned URL 발급 성공"),
 
     /// 201 CREATED
     MEMBER_SIGNUP_SUCCESS(HttpStatus.CREATED, "회원가입 성공"),
+    MEDIA_ADD_SUCCESS(HttpStatus.CREATED, "미디어 추가 성공"),
 
-    /// 200 OK
-    MEMBER_WITHDRAW_SUCCESS(HttpStatus.OK, "회원탈퇴 성공"),
-
-    /// 200 OK
-    TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
+    /// 204 NO CONTENT
+    MEDIA_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "미디어 삭제 성공"),
 
 
 


### PR DESCRIPTION
## Related Issue
- close #2 

## Why - 해결하려는 문제가 무엇인가요?

- 클라이언트가 S3에 파일을 직접 업로드할 수 있도록 보안이 적용된 Presigned URL 발급 기능
- S3 로직이 도메인 비즈니스 로직과의 강결합을 방지하고, SRP 준수를 위해 분리

## What - 무엇이 변경됐나요?

### 구현 기능 
- AWS SDK(v2) S3Presigner를 이용한 Presigned URL 발급 로직 구현 (AwsS3Service)
- S3 파일 단건 삭제 유틸리티 메서드 추가 (추후 도메인 계층에서 호출 목적)
- Presigned URL 발급을 위한 REST API 엔드포인트 개설 (AwsS3Controller)

### 주요 변경사항
- AwsS3Directory (Enum): S3 업로드 경로(vendors, products 등)를 컴파일 타임에 안전하게 관리
- AwsS3RequestDTO / AwsS3ResponseDTO: URL 발급 요청/응답 레코드 정의
- SuccessStatus: 응답 상태 코드 및 메시지(AWS_S3_PRESIGNED_URL_SUCCESS) 추가

## How - 어떻게 해결했나요?

### 핵심 로직 설명
  - 클라이언트가 `directory` (Enum), `originalFileName`, `contentType`을 요청하면, 서버는 유니크한 `fileKey`(디렉토리명 + UUID + 확장자)를 생성합니다.
  - 생성된 `fileKey`를 바탕으로 `PutObjectPresignRequest`를 빌드하여 S3에 PUT 요청을 보낼 수 있는 1회용 `presignedUrl`을 발급합니다.
  - 이후 클라이언트가 이미지를 렌더링할 때 사용할 수 있도록 CloudFront URL도 함께 반환합니다.

### 예외 사항
- 단건 발급 API만 제공, 추후 프론트에서는 병렬 호출하는 방식으로 사용

## 기타 코멘트

- 추후 각 도메인에서 파일 삭제 시 `AwsS3Service.deleteFile(fileKey)` 호출