### PR TITLE
[feat] 일반 회원가입 정보 확장 및 소셜 추가정보 저장 API 구현

### DIFF
--- a/src/main/java/com/wedit/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/wedit/backend/api/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.wedit.backend.api.member.controller;
 
 import com.wedit.backend.api.member.dto.MemberLoginRequestDTO;
 import com.wedit.backend.api.member.dto.MemberLoginResponseDTO;
+import com.wedit.backend.api.member.dto.MemberSocialAdditionalInfoRequestDTO;
 import com.wedit.backend.api.member.dto.MemberSignupRequestDTO;
 import com.wedit.backend.api.member.service.MemberService;
 import com.wedit.backend.common.config.security.entity.SecurityMember;
@@ -80,6 +81,24 @@ public class MemberController {
 
         memberService.withdraw(securityMember.getMember().getId());
         return ApiResponse.successOnly(SuccessStatus.MEMBER_WITHDRAW_SUCCESS);
+    }
+
+    @PostMapping("/social/additional-info")
+    public ResponseEntity<ApiResponse<Void>> saveSocialAdditionalInfo(
+            @Valid @RequestBody MemberSocialAdditionalInfoRequestDTO dto) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof SecurityMember securityMember)) {
+            return ResponseEntity.status(ErrorStatus.UNAUTHORIZED_USER.getStatusCode())
+                    .body(ApiResponse.fail(ErrorStatus.UNAUTHORIZED_USER.getStatusCode(), "인증이 필요합니다."));
+        }
+
+        try {
+            memberService.saveSocialAdditionalInfo(securityMember.getMember().getId(), dto);
+            return ApiResponse.successOnly(SuccessStatus.MEMBER_PROFILE_UPDATE_SUCCESS);
+        } catch (IllegalStateException ex) {
+            return ResponseEntity.status(ErrorStatus.BAD_REQUEST_MISSING_PARAM.getStatusCode())
+                    .body(ApiResponse.fail(ErrorStatus.BAD_REQUEST_MISSING_PARAM.getStatusCode(), ex.getMessage()));
+        }
     }
 
     private Optional<String> extractBearer(String headerValue) {

--- a/src/main/java/com/wedit/backend/api/member/dto/MemberSocialAdditionalInfoRequestDTO.java
+++ b/src/main/java/com/wedit/backend/api/member/dto/MemberSocialAdditionalInfoRequestDTO.java
@@ -1,11 +1,9 @@
 package com.wedit.backend.api.member.dto;
 
 import com.wedit.backend.api.member.entity.SpouseType;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,23 +11,7 @@ import java.time.LocalDate;
 
 @Getter
 @Setter
-public class MemberSignupRequestDTO {
-
-    @Email
-    @NotBlank
-    private String email;
-
-    @NotBlank
-    @Size(min = 8, max = 64)
-    @Pattern(
-            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[^A-Za-z\\d]).{8,64}$",
-            message = "비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 포함해야 합니다."
-    )
-    private String password;
-
-    @NotBlank
-    @Size(max = 50)
-    private String name;
+public class MemberSocialAdditionalInfoRequestDTO {
 
     @NotNull
     private LocalDate birthDate;

--- a/src/main/java/com/wedit/backend/api/member/entity/Member.java
+++ b/src/main/java/com/wedit/backend/api/member/entity/Member.java
@@ -4,6 +4,7 @@ import com.wedit.backend.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -28,8 +29,28 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = true, unique = true, length = 100)
     private String oauthId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true, length = 20)
+    private SocialProvider socialProvider;
+
+    @Column(nullable = true, length = 100)
+    private String socialLoginId;
+
     @Column(nullable = false, length = 50)
     private String name;
+
+    @Column(nullable = true)
+    private LocalDate birthDate;
+
+    @Column(nullable = true, length = 30)
+    private String phoneNumber;
+
+    @Column(nullable = true)
+    private LocalDate weddingDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true, length = 10)
+    private SpouseType spouseType;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -47,6 +68,13 @@ public class Member extends BaseTimeEntity {
     public Member update(String name) {
         this.name = name;
         return this;
+    }
+
+    public void updateProfile(LocalDate birthDate, String phoneNumber, LocalDate weddingDate, SpouseType spouseType) {
+        this.birthDate = birthDate;
+        this.phoneNumber = phoneNumber;
+        this.weddingDate = weddingDate;
+        this.spouseType = spouseType;
     }
 
     public void markDeleted() {

--- a/src/main/java/com/wedit/backend/api/member/entity/SocialProvider.java
+++ b/src/main/java/com/wedit/backend/api/member/entity/SocialProvider.java
@@ -1,0 +1,8 @@
+package com.wedit.backend.api.member.entity;
+
+public enum SocialProvider {
+    GOOGLE,
+    NAVER,
+    KAKAO,
+    APPLE
+}

--- a/src/main/java/com/wedit/backend/api/member/entity/SpouseType.java
+++ b/src/main/java/com/wedit/backend/api/member/entity/SpouseType.java
@@ -1,0 +1,6 @@
+package com.wedit.backend.api.member.entity;
+
+public enum SpouseType {
+    GROOM,
+    BRIDE
+}

--- a/src/main/java/com/wedit/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/wedit/backend/api/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.wedit.backend.api.member.service;
 
 import com.wedit.backend.api.member.dto.MemberLoginRequestDTO;
 import com.wedit.backend.api.member.dto.MemberLoginResponseDTO;
+import com.wedit.backend.api.member.dto.MemberSocialAdditionalInfoRequestDTO;
 import com.wedit.backend.api.member.dto.MemberSignupRequestDTO;
 import com.wedit.backend.api.member.entity.Member;
 import com.wedit.backend.api.member.entity.Role;
@@ -36,6 +37,10 @@ public class MemberService {
                 .email(dto.getEmail())
                 .password(passwordEncoder.encode(dto.getPassword()))
                 .name(dto.getName())
+                .birthDate(dto.getBirthDate())
+                .phoneNumber(dto.getPhoneNumber())
+                .weddingDate(dto.getWeddingDate())
+                .spouseType(dto.getSpouseType())
                 .role(Role.ROLE_USER)
                 .build();
 
@@ -73,6 +78,27 @@ public class MemberService {
 
         refreshTokenService.deleteAllByMemberId(memberId);
         member.markDeleted();
+    }
+
+    @Transactional
+    public void saveSocialAdditionalInfo(Long memberId, MemberSocialAdditionalInfoRequestDTO dto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자입니다."));
+
+        if (member.isDeleted()) {
+            throw new NotFoundException("존재하지 않는 사용자입니다.");
+        }
+
+        if (member.getOauthId() == null) {
+            throw new IllegalStateException("소셜 로그인 회원만 추가 정보를 저장할 수 있습니다.");
+        }
+
+        member.updateProfile(
+                dto.getBirthDate(),
+                dto.getPhoneNumber(),
+                dto.getWeddingDate(),
+                dto.getSpouseType()
+        );
     }
 
     @Transactional

--- a/src/main/java/com/wedit/backend/common/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/wedit/backend/common/oauth2/OAuthAttributes.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import com.wedit.backend.api.member.entity.Member;
 import com.wedit.backend.api.member.entity.Role;
+import com.wedit.backend.api.member.entity.SocialProvider;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -106,6 +107,8 @@ public class OAuthAttributes {
 
 		return Member.builder()
 			.oauthId(generatedUserId)
+			.socialProvider(SocialProvider.valueOf(socialProvider.toUpperCase()))
+			.socialLoginId(socialId)
 			.name(name)
 			.email(email)
 			.password("OAUTH_USER")

--- a/src/main/java/com/wedit/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/wedit/backend/common/response/SuccessStatus.java
@@ -24,6 +24,9 @@ public enum SuccessStatus {
     /// 204 NO CONTENT
     MEDIA_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "미디어 삭제 성공"),
 
+    /// 200 OK
+    MEMBER_PROFILE_UPDATE_SUCCESS(HttpStatus.OK, "회원 추가정보 저장 성공"),
+
 
 
     ;


### PR DESCRIPTION
## Related Issue
- close #6

## Why - 해결하려는 문제가 무엇인가요?

- 일반/소셜 로그인 사용자의 추가 프로필 정보(생년월일, 전화번호, 결혼예정일, 부부 형태)를 저장하는 경로가 부족했습니다.

- 회원가입 및 소셜 로그인 이후에도 동일한 회원 도메인에서 정보를 일관되게 관리할 수 있도록 확장이 필요했습니다.

## What - 무엇이 변경됐나요?

- `Member` 엔티티에 추가 프로필 필드(`birthDate`, `phoneNumber`, `weddingDate`, `spouseType`)와 소셜 식별 필드(`socialProvider`, `socialLoginId`)를 추가했습니다.

- 일반 회원가입 DTO/서비스에 추가 정보 저장을 반영하고 비밀번호 정책(8자 이상, 영문/숫자/특수문자 조합) 검증을 적용했습니다.

- 소셜 로그인 사용자용 추가 정보 저장 API `POST /api/v1/member/social/additional-info`를 구현했습니다.

## How - 어떻게 해결했나요?

- 신규 enum(`SpouseType`, `SocialProvider`)을 도입하고, 서비스 레이어에서 일반 회원가입과 소셜 추가정보 저장 로직을 분리 구현했습니다.

- OAuth 사용자 생성 시 소셜 제공자/소셜 ID를 엔티티에 별도 저장하도록 매핑을 확장했습니다.

- 인증 사용자 검증 후 소셜 로그인 회원만 추가정보를 저장할 수 있도록 제약했습니다.

## 기타 코멘트

- 테스트: `./gradlew test` 통과
- 브랜치: `codex/feat/member-auth-profile`