### PR TITLE
[feat] 업체 상세 CRUD API

### DIFF
--- a/docs/exec-plans/active/20260426-vendor-detail-crud-api.md
+++ b/docs/exec-plans/active/20260426-vendor-detail-crud-api.md
@@ -1,0 +1,64 @@
+# EXEC_PLAN: [feat] 업체 상세 CRUD API
+
+- Task slug: `vendor-detail-crud-api`
+- Base branch: `main`
+- Feature branch: `codex/vendor-detail-crud-api`
+- Worktree: `/Users/hyunwoo/Desktop/Project/Wedit/wedit-backend-worktrees/vendor-detail-crud-api`
+- Port: `18080`
+- Log dir: `/Users/hyunwoo/Desktop/Project/Wedit/wedit-backend-worktrees/wedit-backend-logs/vendor-detail-crud-api`
+- Status: `verified`
+
+## Required Reads
+- [x] AGENTS.md
+- [x] ARCHITECTURE.md
+- [x] docs/index.md
+
+## Related Docs
+- [x] docs/architecture/backend-map.md
+- [x] docs/testing/codex-harness.md
+- [x] docs/specs/2026-wedit-backend-capabilities.md
+- [x] docs/specs/2026-wedit-backend-coverage-matrix.md
+- [x] docs/exec-plans/active/20260425-vendor-crud.md
+
+## Related Feature IDs
+- [x] vendor-detail-main-photo
+- [x] vendor-detail-summary
+- [x] vendor-detail-gallery-and-location
+
+## Doc Notes
+- Public API additions must keep the `controller -> service -> repository -> entity` dependency direction; controllers must not access repositories directly.
+- Tests must run under the `test` profile without real MySQL, OAuth providers, or external network calls.
+- The product spec wants vendor detail to expose summary, main photo, gallery, and location as one read model. This task extends that into full CRUD for the vendor detail resource.
+- Existing `20260425-vendor-crud` plan establishes soft deletion via `isActive`; this task should preserve that policy for delete operations.
+- `scripts/task/init-task.sh vendor-detail-crud-api "[feat] 업체 상세 CRUD API"` created the worktree branch, but the root checkout changed to `main` before helper scripts completed. Port/log/EXEC_PLAN were completed from the generated worktree.
+
+## Goal
+- Provide complete vendor detail CRUD API coverage for creating, reading, listing, updating, and soft-deleting vendor detail records, including representative photo, gallery/location data, and subtype-specific summary fields where the current domain model supports them.
+
+## Approach
+- Inspect current vendor/product entities, repositories, response wrappers, validation style, and existing tests before editing.
+- Add controller/service/dto layers under `api/vendor`, keeping repository access in the service.
+- Use `VendorCategory` to route subtype create/update behavior and expose a stable read DTO containing core summary, subtype payload, main media, gallery, and location fields.
+- Keep delete as a soft delete using the existing active flag, and keep inactive records out of list/read contracts unless explicitly needed for tests.
+- Add MockMvc/JPA-backed tests for normal CRUD, not-found/inactive edge cases, and request validation failures.
+- Update the spec coverage matrix evidence for the three vendor detail feature rows after tests are in place.
+
+## Step Plan
+- Inspect `api/vendor`, `api/product`, common response/exception types, security test setup, and existing vendor tests.
+- Define request/response DTOs for vendor detail create/update/read/list contracts.
+- Implement service logic for category-specific entity creation/update and media ordering/main-photo selection.
+- Add REST endpoints for create, list, detail read, update, and delete.
+- Add integration tests covering successful CRUD, validation errors, and inactive/not-found behavior.
+- Update docs/specs coverage matrix and run `./gradlew check build --no-daemon`.
+
+## Done Criteria
+- Vendor detail CRUD endpoints are implemented through controller/service/repository/entity layers.
+- Read responses include summary, category, subtype details, representative media, gallery media, and location/map fields where available.
+- Delete performs soft deletion and inactive vendors no longer appear in normal list/detail reads.
+- Tests cover normal behavior, edge cases, and input validation.
+- `./gradlew check build --no-daemon` passes before commit.
+
+## Verification
+- [x] `./gradlew test --tests com.wedit.backend.api.vendor.VendorDetailCrudIntegrationTest --no-daemon`
+- [x] `python3 scripts/specs/verify_feature_harness.py`
+- [x] `./gradlew check build --no-daemon`

--- a/scripts/hooks/pre-commit.sh
+++ b/scripts/hooks/pre-commit.sh
@@ -42,7 +42,13 @@ if contains_path '^src/main/' && ! contains_path '^src/test/'; then
 fi
 
 verify_command="${STRICT_VERIFY_COMMAND:-./gradlew check build --no-daemon}"
-(cd "${repo}" && eval "${verify_command}") || fail "verification command failed: ${verify_command}"
+(
+  while IFS= read -r git_env_var; do
+    unset "${git_env_var}"
+  done < <(git -C "${repo}" rev-parse --local-env-vars)
+  cd "${repo}"
+  eval "${verify_command}"
+) || fail "verification command failed: ${verify_command}"
 
 LAST_VERIFY_COMMAND="${verify_command}"
 LAST_VERIFY_STATUS="passed"

--- a/src/main/java/com/wedit/backend/api/vendor/controller/VendorController.java
+++ b/src/main/java/com/wedit/backend/api/vendor/controller/VendorController.java
@@ -1,7 +1,7 @@
 package com.wedit.backend.api.vendor.controller;
 
-import com.wedit.backend.api.vendor.dto.VendorResponseDTO;
-import com.wedit.backend.api.vendor.dto.VendorUpsertRequestDTO;
+import com.wedit.backend.api.vendor.dto.VendorDetailRequestDTO;
+import com.wedit.backend.api.vendor.dto.VendorDetailResponseDTO;
 import com.wedit.backend.api.vendor.entity.VendorCategory;
 import com.wedit.backend.api.vendor.service.VendorService;
 import com.wedit.backend.common.exception.NotFoundException;
@@ -32,25 +32,26 @@ public class VendorController {
     private final VendorService vendorService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<VendorResponseDTO>> createVendor(
-            @Valid @RequestBody VendorUpsertRequestDTO request
+    public ResponseEntity<ApiResponse<VendorDetailResponseDTO>> createVendor(
+            @Valid @RequestBody VendorDetailRequestDTO request
     ) {
         return ApiResponse.success(SuccessStatus.VENDOR_CREATE_SUCCESS, vendorService.createVendor(request));
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<VendorResponseDTO>>> getVendors(
+    public ResponseEntity<ApiResponse<List<VendorDetailResponseDTO>>> getVendors(
             @RequestParam(required = false) VendorCategory category,
+            @RequestParam(required = false) String region,
             @RequestParam(defaultValue = "false") boolean includeInactive
     ) {
         return ApiResponse.success(
                 SuccessStatus.VENDOR_LIST_SUCCESS,
-                vendorService.getVendors(category, includeInactive)
+                vendorService.getVendors(category, region, includeInactive)
         );
     }
 
     @GetMapping("/{vendorId}")
-    public ResponseEntity<ApiResponse<VendorResponseDTO>> getVendor(
+    public ResponseEntity<ApiResponse<VendorDetailResponseDTO>> getVendor(
             @PathVariable Long vendorId,
             @RequestParam(defaultValue = "false") boolean includeInactive
     ) {
@@ -61,9 +62,9 @@ public class VendorController {
     }
 
     @PutMapping("/{vendorId}")
-    public ResponseEntity<ApiResponse<VendorResponseDTO>> updateVendor(
+    public ResponseEntity<ApiResponse<VendorDetailResponseDTO>> updateVendor(
             @PathVariable Long vendorId,
-            @Valid @RequestBody VendorUpsertRequestDTO request
+            @Valid @RequestBody VendorDetailRequestDTO request
     ) {
         return ApiResponse.success(
                 SuccessStatus.VENDOR_UPDATE_SUCCESS,

--- a/src/main/java/com/wedit/backend/api/vendor/dto/VendorDetailRequestDTO.java
+++ b/src/main/java/com/wedit/backend/api/vendor/dto/VendorDetailRequestDTO.java
@@ -1,0 +1,97 @@
+package com.wedit.backend.api.vendor.dto;
+
+import com.wedit.backend.api.vendor.entity.VendorCategory;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class VendorDetailRequestDTO {
+
+    @NotNull
+    private VendorCategory category;
+
+    @NotBlank
+    @Size(max = 100)
+    private String name;
+
+    @NotBlank
+    @Size(max = 100)
+    private String region;
+
+    @NotBlank
+    @Size(max = 255)
+    private String fullAddress;
+
+    @Size(max = 255)
+    private String addressDetail;
+
+    @Size(max = 50)
+    private String contactInfo;
+
+    @DecimalMin(value = "-90.0")
+    @DecimalMax(value = "90.0")
+    private Double latitude;
+
+    @DecimalMin(value = "-180.0")
+    @DecimalMax(value = "180.0")
+    private Double longitude;
+
+    @Size(max = 500)
+    private String kakaoMapUrl;
+
+    @Size(max = 500)
+    private String website;
+
+    @Size(max = 500)
+    private String instagramUrl;
+
+    @Size(max = 2000)
+    private String description;
+
+    @PositiveOrZero
+    private Integer capacity;
+
+    @PositiveOrZero
+    private Integer hallCount;
+
+    private Boolean mealAvailable;
+
+    private Boolean parkingAvailable;
+
+    private Boolean outdoor;
+
+    @PositiveOrZero
+    private Integer photographerCount;
+
+    @Size(max = 255)
+    private String shootingStyle;
+
+    @Size(max = 100)
+    private String brand;
+
+    @PositiveOrZero
+    private Integer fittingCount;
+
+    @PositiveOrZero
+    private Integer artistCount;
+
+    private Boolean homeCareAvailable;
+
+    @PositiveOrZero
+    private Long homeCareFee;
+
+    @Valid
+    @Size(max = 30)
+    private List<VendorMediaRequestDTO> mediaList = new ArrayList<>();
+}

--- a/src/main/java/com/wedit/backend/api/vendor/dto/VendorDetailResponseDTO.java
+++ b/src/main/java/com/wedit/backend/api/vendor/dto/VendorDetailResponseDTO.java
@@ -1,0 +1,80 @@
+package com.wedit.backend.api.vendor.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.wedit.backend.api.vendor.entity.Vendor;
+import com.wedit.backend.api.vendor.entity.VendorCategory;
+import com.wedit.backend.api.vendor.entity.VendorMedia;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class VendorDetailResponseDTO {
+
+    private final Long id;
+    private final VendorCategory category;
+    private final String name;
+    private final String region;
+    private final String fullAddress;
+    private final String addressDetail;
+    private final String contactInfo;
+    private final Double latitude;
+    private final Double longitude;
+    private final String kakaoMapUrl;
+    private final String website;
+    private final String instagramUrl;
+    private final String description;
+    private final boolean active;
+    private final VendorSubtypeResponseDTO details;
+    private final VendorMediaResponseDTO mainMedia;
+    private final List<VendorMediaResponseDTO> mediaList;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static VendorDetailResponseDTO from(Vendor vendor) {
+        List<VendorMediaResponseDTO> mediaResponses = sortedMedia(vendor).stream()
+                .map(VendorMediaResponseDTO::from)
+                .toList();
+
+        return VendorDetailResponseDTO.builder()
+                .id(vendor.getId())
+                .category(vendor.getVendorCategory())
+                .name(vendor.getName())
+                .region(vendor.getRegion())
+                .fullAddress(vendor.getFullAddress())
+                .addressDetail(vendor.getAddressDetail())
+                .contactInfo(vendor.getContactInfo())
+                .latitude(vendor.getLatitude())
+                .longitude(vendor.getLongitude())
+                .kakaoMapUrl(vendor.getKakaoMapUrl())
+                .website(vendor.getWebsite())
+                .instagramUrl(vendor.getInstagramUrl())
+                .description(vendor.getDescription())
+                .active(vendor.isActive())
+                .details(VendorSubtypeResponseDTO.from(vendor))
+                .mainMedia(resolveMainMedia(mediaResponses))
+                .mediaList(mediaResponses)
+                .createdAt(vendor.getCreatedAt())
+                .updatedAt(vendor.getUpdatedAt())
+                .build();
+    }
+
+    private static List<VendorMedia> sortedMedia(Vendor vendor) {
+        return vendor.getMediaList().stream()
+                .sorted(Comparator.comparing(VendorMedia::getOrdering)
+                        .thenComparing(media -> media.getId() == null ? Long.MAX_VALUE : media.getId()))
+                .toList();
+    }
+
+    private static VendorMediaResponseDTO resolveMainMedia(List<VendorMediaResponseDTO> mediaList) {
+        return mediaList.stream()
+                .filter(VendorMediaResponseDTO::isThumbnail)
+                .findFirst()
+                .orElseGet(() -> mediaList.isEmpty() ? null : mediaList.getFirst());
+    }
+}

--- a/src/main/java/com/wedit/backend/api/vendor/dto/VendorMediaRequestDTO.java
+++ b/src/main/java/com/wedit/backend/api/vendor/dto/VendorMediaRequestDTO.java
@@ -1,0 +1,21 @@
+package com.wedit.backend.api.vendor.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class VendorMediaRequestDTO {
+
+    @NotBlank
+    @Size(max = 500)
+    private String url;
+
+    @PositiveOrZero
+    private Integer ordering;
+
+    private boolean thumbnail;
+}

--- a/src/main/java/com/wedit/backend/api/vendor/dto/VendorMediaResponseDTO.java
+++ b/src/main/java/com/wedit/backend/api/vendor/dto/VendorMediaResponseDTO.java
@@ -1,0 +1,24 @@
+package com.wedit.backend.api.vendor.dto;
+
+import com.wedit.backend.api.vendor.entity.VendorMedia;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class VendorMediaResponseDTO {
+
+    private final Long id;
+    private final String url;
+    private final Integer ordering;
+    private final boolean thumbnail;
+
+    public static VendorMediaResponseDTO from(VendorMedia media) {
+        return VendorMediaResponseDTO.builder()
+                .id(media.getId())
+                .url(media.getUrl())
+                .ordering(media.getOrdering())
+                .thumbnail(media.isThumbnail())
+                .build();
+    }
+}

--- a/src/main/java/com/wedit/backend/api/vendor/dto/VendorSubtypeResponseDTO.java
+++ b/src/main/java/com/wedit/backend/api/vendor/dto/VendorSubtypeResponseDTO.java
@@ -1,0 +1,60 @@
+package com.wedit.backend.api.vendor.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.wedit.backend.api.vendor.entity.Dress;
+import com.wedit.backend.api.vendor.entity.Makeup;
+import com.wedit.backend.api.vendor.entity.Studio;
+import com.wedit.backend.api.vendor.entity.Vendor;
+import com.wedit.backend.api.vendor.entity.WeddingHall;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class VendorSubtypeResponseDTO {
+
+    private final Integer capacity;
+    private final Integer hallCount;
+    private final Boolean mealAvailable;
+    private final Boolean parkingAvailable;
+    private final Boolean outdoor;
+    private final Integer photographerCount;
+    private final String shootingStyle;
+    private final String brand;
+    private final Integer fittingCount;
+    private final Integer artistCount;
+    private final Boolean homeCareAvailable;
+    private final Long homeCareFee;
+
+    public static VendorSubtypeResponseDTO from(Vendor vendor) {
+        VendorSubtypeResponseDTOBuilder builder = VendorSubtypeResponseDTO.builder();
+
+        if (vendor instanceof WeddingHall weddingHall) {
+            return builder.capacity(weddingHall.getCapacity())
+                    .hallCount(weddingHall.getHallCount())
+                    .mealAvailable(weddingHall.isMealAvailable())
+                    .parkingAvailable(weddingHall.isParkingAvailable())
+                    .build();
+        }
+
+        if (vendor instanceof Studio studio) {
+            return builder.outdoor(studio.isOutdoor())
+                    .photographerCount(studio.getPhotographerCount())
+                    .shootingStyle(studio.getShootingStyle())
+                    .build();
+        }
+
+        if (vendor instanceof Dress dress) {
+            return builder.brand(dress.getBrand())
+                    .fittingCount(dress.getFittingCount())
+                    .build();
+        }
+
+        Makeup makeup = (Makeup) vendor;
+        return builder.artistCount(makeup.getArtistCount())
+                .homeCareAvailable(makeup.isHomeCareAvailable())
+                .homeCareFee(makeup.getHomeCareFee())
+                .build();
+    }
+}

--- a/src/main/java/com/wedit/backend/api/vendor/entity/Vendor.java
+++ b/src/main/java/com/wedit/backend/api/vendor/entity/Vendor.java
@@ -90,6 +90,11 @@ public abstract class Vendor extends BaseTimeEntity {
         media.assignVendor(this);
     }
 
+    public void replaceMediaList(List<VendorMedia> mediaList) {
+        this.mediaList.clear();
+        mediaList.forEach(this::addMedia);
+    }
+
     public void updateCommonInfo(String name, String region, String fullAddress, String addressDetail,
                                  String contactInfo, Double latitude, Double longitude,
                                  String kakaoMapUrl, String website, String instagramUrl, String description) {

--- a/src/main/java/com/wedit/backend/api/vendor/repository/VendorRepository.java
+++ b/src/main/java/com/wedit/backend/api/vendor/repository/VendorRepository.java
@@ -1,8 +1,10 @@
 package com.wedit.backend.api.vendor.repository;
 
 import com.wedit.backend.api.vendor.entity.Vendor;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,4 +16,16 @@ public interface VendorRepository extends JpaRepository<Vendor, Long> {
     Optional<Vendor> findByIdAndIsActiveTrue(Long id);
 
     List<Vendor> findAllByIsActiveTrue(Sort sort);
+
+    @Query("select distinct v from Vendor v left join fetch v.mediaList where v.isActive = true order by v.id desc")
+    List<Vendor> findActiveDetails();
+
+    @Query("select distinct v from Vendor v left join fetch v.mediaList order by v.id desc")
+    List<Vendor> findAllDetails();
+
+    @Query("select distinct v from Vendor v left join fetch v.mediaList where v.id = :id and v.isActive = true")
+    Optional<Vendor> findActiveDetailById(@Param("id") Long id);
+
+    @Query("select distinct v from Vendor v left join fetch v.mediaList where v.id = :id")
+    Optional<Vendor> findDetailById(@Param("id") Long id);
 }

--- a/src/main/java/com/wedit/backend/api/vendor/service/VendorService.java
+++ b/src/main/java/com/wedit/backend/api/vendor/service/VendorService.java
@@ -1,17 +1,18 @@
 package com.wedit.backend.api.vendor.service;
 
-import com.wedit.backend.api.vendor.dto.VendorResponseDTO;
-import com.wedit.backend.api.vendor.dto.VendorUpsertRequestDTO;
+import com.wedit.backend.api.vendor.dto.VendorDetailRequestDTO;
+import com.wedit.backend.api.vendor.dto.VendorDetailResponseDTO;
+import com.wedit.backend.api.vendor.dto.VendorMediaRequestDTO;
 import com.wedit.backend.api.vendor.entity.Dress;
 import com.wedit.backend.api.vendor.entity.Makeup;
 import com.wedit.backend.api.vendor.entity.Studio;
 import com.wedit.backend.api.vendor.entity.Vendor;
 import com.wedit.backend.api.vendor.entity.VendorCategory;
+import com.wedit.backend.api.vendor.entity.VendorMedia;
 import com.wedit.backend.api.vendor.entity.WeddingHall;
 import com.wedit.backend.api.vendor.repository.VendorRepository;
 import com.wedit.backend.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -22,48 +23,52 @@ import java.util.List;
 @RequiredArgsConstructor
 public class VendorService {
 
-    private static final Sort DEFAULT_SORT = Sort.by(Sort.Direction.DESC, "id");
-
     private final VendorRepository vendorRepository;
 
     @Transactional
-    public VendorResponseDTO createVendor(VendorUpsertRequestDTO request) {
+    public VendorDetailResponseDTO createVendor(VendorDetailRequestDTO request) {
         validateRequest(request);
-        Vendor savedVendor = vendorRepository.save(buildVendor(request));
-        return VendorResponseDTO.from(savedVendor);
+        Vendor vendor = buildVendor(request);
+        vendor.replaceMediaList(buildMediaList(request));
+
+        return VendorDetailResponseDTO.from(vendorRepository.save(vendor));
     }
 
     @Transactional(readOnly = true)
-    public List<VendorResponseDTO> getVendors(VendorCategory category, boolean includeInactive) {
+    public List<VendorDetailResponseDTO> getVendors(
+            VendorCategory category,
+            String region,
+            boolean includeInactive
+    ) {
         List<Vendor> vendors = includeInactive
-                ? vendorRepository.findAll(DEFAULT_SORT)
-                : vendorRepository.findAllByIsActiveTrue(DEFAULT_SORT);
+                ? vendorRepository.findAllDetails()
+                : vendorRepository.findActiveDetails();
 
         return vendors.stream()
                 .filter(vendor -> category == null || vendor.getVendorCategory() == category)
-                .map(VendorResponseDTO::from)
+                .filter(vendor -> !StringUtils.hasText(region) || vendor.getRegion().equals(region))
+                .map(VendorDetailResponseDTO::from)
                 .toList();
     }
 
     @Transactional(readOnly = true)
-    public VendorResponseDTO getVendor(Long vendorId, boolean includeInactive) {
+    public VendorDetailResponseDTO getVendor(Long vendorId, boolean includeInactive) {
         Vendor vendor = includeInactive
-                ? findVendor(vendorId)
-                : vendorRepository.findByIdAndIsActiveTrue(vendorId)
-                        .orElseThrow(() -> new NotFoundException("업체를 찾을 수 없습니다."));
+                ? findVendorDetail(vendorId)
+                : findActiveVendorDetail(vendorId);
 
-        return VendorResponseDTO.from(vendor);
+        return VendorDetailResponseDTO.from(vendor);
     }
 
     @Transactional
-    public VendorResponseDTO updateVendor(Long vendorId, VendorUpsertRequestDTO request) {
-        Vendor vendor = findVendor(vendorId);
+    public VendorDetailResponseDTO updateVendor(Long vendorId, VendorDetailRequestDTO request) {
+        validateRequest(request);
+        Vendor vendor = findActiveVendorDetail(vendorId);
 
         if (vendor.getVendorCategory() != request.getCategory()) {
             throw new IllegalArgumentException("업체 카테고리는 변경할 수 없습니다.");
         }
 
-        validateRequest(request);
         vendor.updateCommonInfo(
                 request.getName(),
                 request.getRegion(),
@@ -78,24 +83,28 @@ public class VendorService {
                 request.getDescription()
         );
         applyCategorySpecificFields(vendor, request);
+        vendor.replaceMediaList(buildMediaList(request));
 
-        return VendorResponseDTO.from(vendor);
+        return VendorDetailResponseDTO.from(vendor);
     }
 
     @Transactional
     public void deleteVendor(Long vendorId) {
-        Vendor vendor = findVendor(vendorId);
-        if (vendor.isActive()) {
-            vendor.deactivate();
-        }
+        Vendor vendor = findActiveVendorDetail(vendorId);
+        vendor.deactivate();
     }
 
-    private Vendor findVendor(Long vendorId) {
-        return vendorRepository.findById(vendorId)
+    private Vendor findActiveVendorDetail(Long vendorId) {
+        return vendorRepository.findActiveDetailById(vendorId)
                 .orElseThrow(() -> new NotFoundException("업체를 찾을 수 없습니다."));
     }
 
-    private Vendor buildVendor(VendorUpsertRequestDTO request) {
+    private Vendor findVendorDetail(Long vendorId) {
+        return vendorRepository.findDetailById(vendorId)
+                .orElseThrow(() -> new NotFoundException("업체를 찾을 수 없습니다."));
+    }
+
+    private Vendor buildVendor(VendorDetailRequestDTO request) {
         VendorCategory category = request.getCategory();
 
         if (category == VendorCategory.WEDDING_HALL) {
@@ -173,7 +182,7 @@ public class VendorService {
                 .build();
     }
 
-    private void applyCategorySpecificFields(Vendor vendor, VendorUpsertRequestDTO request) {
+    private void applyCategorySpecificFields(Vendor vendor, VendorDetailRequestDTO request) {
         VendorCategory category = vendor.getVendorCategory();
 
         if (category == VendorCategory.WEDDING_HALL) {
@@ -210,11 +219,35 @@ public class VendorService {
         );
     }
 
-    private void validateRequest(VendorUpsertRequestDTO request) {
+    private List<VendorMedia> buildMediaList(VendorDetailRequestDTO request) {
+        return mediaRequests(request).stream()
+                .map(media -> VendorMedia.builder()
+                        .url(media.getUrl())
+                        .ordering(media.getOrdering())
+                        .isThumbnail(media.isThumbnail())
+                        .build())
+                .toList();
+    }
+
+    private void validateRequest(VendorDetailRequestDTO request) {
         if (request.getLatitude() == null ^ request.getLongitude() == null) {
             throw new IllegalArgumentException("위도와 경도는 함께 입력해야 합니다.");
         }
+        validateMedia(request);
+        validateCategorySpecificFields(request);
+    }
 
+    private void validateMedia(VendorDetailRequestDTO request) {
+        long thumbnailCount = mediaRequests(request).stream()
+                .filter(VendorMediaRequestDTO::isThumbnail)
+                .count();
+
+        if (thumbnailCount > 1) {
+            throw new IllegalArgumentException("대표 이미지는 하나만 지정할 수 있습니다.");
+        }
+    }
+
+    private void validateCategorySpecificFields(VendorDetailRequestDTO request) {
         VendorCategory category = request.getCategory();
 
         if (category == VendorCategory.WEDDING_HALL) {
@@ -245,6 +278,10 @@ public class VendorService {
         }
     }
 
+    private List<VendorMediaRequestDTO> mediaRequests(VendorDetailRequestDTO request) {
+        return request.getMediaList() == null ? List.of() : request.getMediaList();
+    }
+
     private void requireNotNull(Object value, String message) {
         if (value == null) {
             throw new IllegalArgumentException(message);
@@ -257,7 +294,7 @@ public class VendorService {
         }
     }
 
-    private Long normalizeHomeCareFee(VendorUpsertRequestDTO request) {
+    private Long normalizeHomeCareFee(VendorDetailRequestDTO request) {
         return Boolean.TRUE.equals(request.getHomeCareAvailable()) ? request.getHomeCareFee() : null;
     }
 }

--- a/src/test/java/com/wedit/backend/api/vendor/VendorCrudIntegrationTest.java
+++ b/src/test/java/com/wedit/backend/api/vendor/VendorCrudIntegrationTest.java
@@ -76,7 +76,7 @@ class VendorCrudIntegrationTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("업체 생성 성공"))
                 .andExpect(jsonPath("$.data.category").value("WEDDING_HALL"))
-                .andExpect(jsonPath("$.data.capacity").value(320))
+                .andExpect(jsonPath("$.data.details.capacity").value(320))
                 .andExpect(jsonPath("$.data.active").value(true));
 
         Vendor savedVendor = vendorRepository.findAll().getFirst();
@@ -112,9 +112,9 @@ class VendorCrudIntegrationTest {
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.message").value("업체 수정 성공"))
                 .andExpect(jsonPath("$.data.name").value("글로우 메이크업 시그니처"))
-                .andExpect(jsonPath("$.data.artistCount").value(5))
-                .andExpect(jsonPath("$.data.homeCareAvailable").value(false))
-                .andExpect(jsonPath("$.data.homeCareFee").doesNotExist());
+                .andExpect(jsonPath("$.data.details.artistCount").value(5))
+                .andExpect(jsonPath("$.data.details.homeCareAvailable").value(false))
+                .andExpect(jsonPath("$.data.details.homeCareFee").doesNotExist());
 
         Makeup updatedVendor = (Makeup) vendorRepository.findById(savedVendor.getId()).orElseThrow();
         assertThat(updatedVendor.getName()).isEqualTo("글로우 메이크업 시그니처");

--- a/src/test/java/com/wedit/backend/api/vendor/VendorDetailCrudIntegrationTest.java
+++ b/src/test/java/com/wedit/backend/api/vendor/VendorDetailCrudIntegrationTest.java
@@ -1,0 +1,362 @@
+package com.wedit.backend.api.vendor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wedit.backend.api.vendor.entity.Dress;
+import com.wedit.backend.api.vendor.entity.Studio;
+import com.wedit.backend.api.vendor.entity.Vendor;
+import com.wedit.backend.api.vendor.repository.VendorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:wedit-vendor-detail;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("Vendor detail CRUD 통합 테스트")
+class VendorDetailCrudIntegrationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private VendorRepository vendorRepository;
+
+    @BeforeEach
+    void setUp() {
+        vendorRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("업체 상세를 생성, 조회, 수정, 삭제할 수 있다")
+    void createReadUpdateDeleteVendorDetail() throws Exception {
+        MvcResult createResult = mockMvc.perform(post("/api/v1/vendors")
+                        .with(vendorAdmin())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(weddingHallPayload("라움 웨딩홀"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("업체 생성 성공"))
+                .andExpect(jsonPath("$.data.category").value("WEDDING_HALL"))
+                .andExpect(jsonPath("$.data.details.capacity").value(320))
+                .andExpect(jsonPath("$.data.mainMedia.url").value("https://cdn.wedit.com/hall-main.jpg"))
+                .andExpect(jsonPath("$.data.mediaList.length()").value(2))
+                .andReturn();
+
+        Long vendorId = responseDataId(createResult);
+
+        mockMvc.perform(get("/api/v1/vendors/{vendorId}", vendorId)
+                        .with(vendorAdmin()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("업체 상세 조회 성공"))
+                .andExpect(jsonPath("$.data.id").value(vendorId))
+                .andExpect(jsonPath("$.data.fullAddress").value("서울시 강남구 웨딩로 1"))
+                .andExpect(jsonPath("$.data.latitude").value(37.501))
+                .andExpect(jsonPath("$.data.longitude").value(127.039))
+                .andExpect(jsonPath("$.data.kakaoMapUrl").value("https://map.kakao.com/link/raum"))
+                .andExpect(jsonPath("$.data.mediaList[0].url").value("https://cdn.wedit.com/hall-main.jpg"));
+
+        mockMvc.perform(put("/api/v1/vendors/{vendorId}", vendorId)
+                        .with(vendorAdmin())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(updatedWeddingHallPayload())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("업체 수정 성공"))
+                .andExpect(jsonPath("$.data.name").value("라움 웨딩홀 리뉴얼"))
+                .andExpect(jsonPath("$.data.details.capacity").value(420))
+                .andExpect(jsonPath("$.data.mainMedia.url").value("https://cdn.wedit.com/hall-renewal.jpg"))
+                .andExpect(jsonPath("$.data.mediaList.length()").value(1));
+
+        Vendor updatedVendor = vendorRepository.findDetailById(vendorId).orElseThrow();
+        assertThat(updatedVendor.getName()).isEqualTo("라움 웨딩홀 리뉴얼");
+        assertThat(updatedVendor.getMediaList()).hasSize(1);
+
+        mockMvc.perform(delete("/api/v1/vendors/{vendorId}", vendorId)
+                        .with(vendorAdmin()))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/v1/vendors/{vendorId}", vendorId)
+                        .with(vendorAdmin()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("업체를 찾을 수 없습니다."));
+
+        mockMvc.perform(get("/api/v1/vendors/{vendorId}", vendorId)
+                        .with(vendorAdmin())
+                        .param("includeInactive", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.active").value(false));
+    }
+
+    @Test
+    @DisplayName("업체 목록은 카테고리와 지역으로 필터링하고 기본적으로 비활성 업체를 숨긴다")
+    void listFiltersByCategoryAndRegionAndHidesInactiveVendors() throws Exception {
+        Studio studio = vendorRepository.saveAndFlush(Studio.builder()
+                .name("모먼트 스튜디오")
+                .region("서울")
+                .fullAddress("서울시 마포구 스튜디오로 1")
+                .isOutdoor(true)
+                .photographerCount(4)
+                .shootingStyle("내추럴")
+                .build());
+        vendorRepository.saveAndFlush(Dress.builder()
+                .name("엘르 드레스")
+                .region("부산")
+                .fullAddress("부산시 해운대구 드레스로 2")
+                .brand("엘르")
+                .fittingCount(3)
+                .build());
+        Dress inactiveDress = vendorRepository.saveAndFlush(Dress.builder()
+                .name("숨겨진 드레스")
+                .region("서울")
+                .fullAddress("서울시 강남구 드레스로 3")
+                .brand("히든")
+                .fittingCount(1)
+                .build());
+        inactiveDress.deactivate();
+        vendorRepository.saveAndFlush(inactiveDress);
+
+        assertThat(vendorRepository.findActiveDetails())
+                .extracting(Vendor::getId)
+                .contains(studio.getId())
+                .doesNotContain(inactiveDress.getId());
+
+        mockMvc.perform(get("/api/v1/vendors")
+                        .with(vendorAdmin())
+                        .param("category", "STUDIO")
+                        .param("region", "서울"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("업체 목록 조회 성공"))
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].id").value(studio.getId()))
+                .andExpect(jsonPath("$.data[0].category").value("STUDIO"));
+
+        mockMvc.perform(get("/api/v1/vendors")
+                        .with(vendorAdmin())
+                        .param("category", "DRESS")
+                        .param("includeInactive", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2));
+    }
+
+    @Test
+    @DisplayName("스튜디오, 드레스, 메이크업 업체 상세를 생성할 수 있다")
+    void createSupportsEveryVendorCategory() throws Exception {
+        mockMvc.perform(post("/api/v1/vendors")
+                        .with(vendorAdmin())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(studioPayload())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.category").value("STUDIO"))
+                .andExpect(jsonPath("$.data.details.outdoor").value(true))
+                .andExpect(jsonPath("$.data.details.shootingStyle").value("화보형"));
+
+        mockMvc.perform(post("/api/v1/vendors")
+                        .with(vendorAdmin())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(dressPayload())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.category").value("DRESS"))
+                .andExpect(jsonPath("$.data.details.brand").value("엘르"))
+                .andExpect(jsonPath("$.data.mainMedia.url").value("https://cdn.wedit.com/dress.jpg"));
+
+        mockMvc.perform(post("/api/v1/vendors")
+                        .with(vendorAdmin())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(makeupPayload())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.category").value("MAKEUP"))
+                .andExpect(jsonPath("$.data.details.artistCount").value(5))
+                .andExpect(jsonPath("$.data.details.homeCareFee").value(150000));
+    }
+
+    @Test
+    @DisplayName("기본 입력 검증에 실패하면 400을 반환한다")
+    void createFailsWhenBeanValidationFails() throws Exception {
+        Map<String, Object> payload = weddingHallPayload("");
+        payload.put("fullAddress", "");
+
+        mockMvc.perform(post("/api/v1/vendors")
+                        .with(vendorAdmin())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(payload)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("대표 이미지를 둘 이상 지정하면 생성에 실패한다")
+    void createFailsWhenMoreThanOneThumbnailExists() throws Exception {
+        Map<String, Object> payload = weddingHallPayload("대표 이미지 중복 홀");
+        payload.put("mediaList", List.of(
+                media("https://cdn.wedit.com/a.jpg", 1, true),
+                media("https://cdn.wedit.com/b.jpg", 2, true)
+        ));
+
+        mockMvc.perform(post("/api/v1/vendors")
+                        .with(vendorAdmin())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(payload)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("대표 이미지는 하나만 지정할 수 있습니다."));
+    }
+
+    @Test
+    @DisplayName("카테고리별 필수 필드가 빠지면 생성에 실패한다")
+    void createFailsWhenCategorySpecificFieldMissing() throws Exception {
+        Map<String, Object> payload = dressPayload();
+        payload.remove("brand");
+
+        mockMvc.perform(post("/api/v1/vendors")
+                        .with(vendorAdmin())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(payload)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("드레스 브랜드는 필수입니다."));
+    }
+
+    @Test
+    @DisplayName("업체 수정 시 카테고리를 바꿀 수 없다")
+    void updateFailsWhenCategoryChanges() throws Exception {
+        Long vendorId = responseDataId(mockMvc.perform(post("/api/v1/vendors")
+                        .with(vendorAdmin())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(weddingHallPayload("카테고리 유지 홀"))))
+                .andExpect(status().isCreated())
+                .andReturn());
+
+        mockMvc.perform(put("/api/v1/vendors/{vendorId}", vendorId)
+                        .with(vendorAdmin())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(studioPayload())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("업체 카테고리는 변경할 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("위도와 경도는 함께 입력해야 한다")
+    void createFailsWhenOnlyOneCoordinateIsProvided() throws Exception {
+        Map<String, Object> payload = weddingHallPayload("좌표 누락 홀");
+        payload.remove("longitude");
+
+        mockMvc.perform(post("/api/v1/vendors")
+                        .with(vendorAdmin())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(payload)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("위도와 경도는 함께 입력해야 합니다."));
+    }
+
+    private Map<String, Object> weddingHallPayload(String name) {
+        Map<String, Object> payload = basePayload("WEDDING_HALL", name);
+        payload.put("capacity", 320);
+        payload.put("hallCount", 2);
+        payload.put("mealAvailable", true);
+        payload.put("parkingAvailable", true);
+        payload.put("mediaList", List.of(
+                media("https://cdn.wedit.com/hall-sub.jpg", 2, false),
+                media("https://cdn.wedit.com/hall-main.jpg", 1, true)
+        ));
+        return payload;
+    }
+
+    private Map<String, Object> updatedWeddingHallPayload() {
+        Map<String, Object> payload = weddingHallPayload("라움 웨딩홀 리뉴얼");
+        payload.put("capacity", 420);
+        payload.put("fullAddress", "서울시 강남구 리뉴얼로 7");
+        payload.put("mediaList", List.of(media("https://cdn.wedit.com/hall-renewal.jpg", 0, false)));
+        return payload;
+    }
+
+    private Map<String, Object> studioPayload() {
+        Map<String, Object> payload = basePayload("STUDIO", "무드 스튜디오");
+        payload.put("outdoor", true);
+        payload.put("photographerCount", 3);
+        payload.put("shootingStyle", "화보형");
+        return payload;
+    }
+
+    private Map<String, Object> dressPayload() {
+        Map<String, Object> payload = basePayload("DRESS", "엘르 드레스");
+        payload.put("brand", "엘르");
+        payload.put("fittingCount", 2);
+        payload.put("mediaList", List.of(media("https://cdn.wedit.com/dress.jpg", 0, false)));
+        return payload;
+    }
+
+    private Map<String, Object> makeupPayload() {
+        Map<String, Object> payload = basePayload("MAKEUP", "글로우 메이크업");
+        payload.put("artistCount", 5);
+        payload.put("homeCareAvailable", true);
+        payload.put("homeCareFee", 150_000L);
+        return payload;
+    }
+
+    private Map<String, Object> basePayload(String category, String name) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("category", category);
+        payload.put("name", name);
+        payload.put("region", "서울");
+        payload.put("fullAddress", "서울시 강남구 웨딩로 1");
+        payload.put("addressDetail", "3층");
+        payload.put("contactInfo", "02-1111-2222");
+        payload.put("latitude", 37.501);
+        payload.put("longitude", 127.039);
+        payload.put("kakaoMapUrl", "https://map.kakao.com/link/raum");
+        payload.put("website", "https://vendor.wedit.com");
+        payload.put("instagramUrl", "https://instagram.com/wedit_vendor");
+        payload.put("description", "업체 상세 소개입니다.");
+        return payload;
+    }
+
+    private Map<String, Object> media(String url, int ordering, boolean thumbnail) {
+        return Map.of(
+                "url", url,
+                "ordering", ordering,
+                "thumbnail", thumbnail
+        );
+    }
+
+    private SecurityMockMvcRequestPostProcessors.UserRequestPostProcessor vendorAdmin() {
+        return SecurityMockMvcRequestPostProcessors.user("vendor-admin").roles("USER");
+    }
+
+    private Long responseDataId(MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        return root.path("data").path("id").asLong();
+    }
+
+    private String json(Object value) throws Exception {
+        return objectMapper.writeValueAsString(value);
+    }
+}


### PR DESCRIPTION
Closes #11

## Issue
- #11
- https://github.com/wedit-official/wedit-backend/issues/11

## EXEC_PLAN
- `docs/exec-plans/active/20260426-vendor-detail-crud-api.md`

## Verification
- Status: `passed`
- Command: `./gradlew check build --no-daemon`
- At: `2026-04-26T13:07:04+0900`
