### PR TITLE
[feat] 로컬 데이터소스 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ processResources.dependsOn copyConfig
 clean {
 	delete fileTree('src/main/resources') {
 		include 'application.yml'
-		include 'application-production.yml'
-		include 'application-staging.yml'
+		include 'application-*.yml'
 	}
 }

--- a/docs/exec-plans/active/20260428-local-config-datasource.md
+++ b/docs/exec-plans/active/20260428-local-config-datasource.md
@@ -3,9 +3,9 @@
 - Task slug: `local-config-datasource`
 - Base branch: `develop`
 - Feature branch: `codex/local-config-datasource`
-- Worktree: `/Users/hyunwoo/Desktop/Project/Wedit/wedit-backend-worktrees/local-config-datasource`
+- Worktree: `../wedit-backend-worktrees/local-config-datasource`
 - Port: `18081`
-- Log dir: `/Users/hyunwoo/Desktop/Project/Wedit/wedit-backend-logs/local-config-datasource`
+- Log dir: `../wedit-backend-logs/local-config-datasource`
 - Status: `completed`
 
 ## Required Reads
@@ -48,3 +48,4 @@ Add `config/src/main/resources/application-local.yml` with local MySQL datasourc
 - Review follow-up: removed the hardcoded local DB password fallback and verified the config contract rejects that leaked default.
 - `./gradlew copyConfig --no-daemon && ./gradlew test --tests com.wedit.backend.config.LocalConfigContractTest --no-daemon`: passed after review follow-up.
 - `./gradlew check build --no-daemon`: passed after review follow-up. Docker image build was skipped by the existing harness because Docker is not available locally.
+- Review follow-up: replaced personal absolute paths with repository-relative paths, tightened datasource URL placeholder assertions, and removed redundant raw file string checks.

--- a/docs/exec-plans/active/20260428-local-config-datasource.md
+++ b/docs/exec-plans/active/20260428-local-config-datasource.md
@@ -1,0 +1,47 @@
+# EXEC_PLAN: Add local datasource config
+
+- Task slug: `local-config-datasource`
+- Base branch: `develop`
+- Feature branch: `codex/local-config-datasource`
+- Worktree: `/Users/hyunwoo/Desktop/Project/Wedit/wedit-backend-worktrees/local-config-datasource`
+- Port: `18081`
+- Log dir: `/Users/hyunwoo/Desktop/Project/Wedit/wedit-backend-logs/local-config-datasource`
+- Status: `completed`
+
+## Required Reads
+- [x] AGENTS.md
+- [x] ARCHITECTURE.md
+- [x] docs/index.md
+
+## Related Docs
+- [x] docs/architecture/backend-map.md
+- [x] docs/testing/codex-harness.md
+- [x] docs/exec-plans/active/harness-rollout.md
+
+## Doc Notes
+- `build.gradle` copies `config/src/main/resources/application*.yml` into `src/main/resources` through `copyConfig` before resource processing.
+- The default active profile is `${SPRING_PROFILES_ACTIVE:local}`.
+- Tests must avoid real MySQL, OAuth providers, and external services; config contract tests should inspect files without opening a database connection.
+
+## Goal
+Restore local boot configuration by adding a `local` profile datasource file to the config submodule.
+
+## Approach
+Add `config/src/main/resources/application-local.yml` with local MySQL datasource settings and environment-variable overrides. Add a config contract test that verifies the local datasource keys exist and remain overrideable without starting the Spring context.
+
+## Step Plan
+1. Initialize the task worktree and config submodule.
+2. Add local datasource YAML under the config submodule.
+3. Add focused config contract tests for normal datasource presence, required input validation, and environment override support.
+4. Run `copyConfig`, focused tests, and full Gradle verification.
+
+## Done Criteria
+- `application-local.yml` exists in the config submodule.
+- `copyConfig` copies the local profile YAML into `src/main/resources`.
+- Focused local config contract tests pass.
+- `./gradlew check build --no-daemon` passes before commit or PR work.
+
+## Verification
+- `./gradlew copyConfig --no-daemon`: passed, `src/main/resources/application-local.yml` was copied.
+- `./gradlew test --tests com.wedit.backend.config.LocalConfigContractTest --no-daemon`: passed.
+- `./gradlew check build --no-daemon`: passed. Docker image build was skipped by the existing harness because Docker is not available locally.

--- a/docs/exec-plans/active/20260428-local-config-datasource.md
+++ b/docs/exec-plans/active/20260428-local-config-datasource.md
@@ -45,3 +45,6 @@ Add `config/src/main/resources/application-local.yml` with local MySQL datasourc
 - `./gradlew copyConfig --no-daemon`: passed, `src/main/resources/application-local.yml` was copied.
 - `./gradlew test --tests com.wedit.backend.config.LocalConfigContractTest --no-daemon`: passed.
 - `./gradlew check build --no-daemon`: passed. Docker image build was skipped by the existing harness because Docker is not available locally.
+- Review follow-up: removed the hardcoded local DB password fallback and verified the config contract rejects that leaked default.
+- `./gradlew copyConfig --no-daemon && ./gradlew test --tests com.wedit.backend.config.LocalConfigContractTest --no-daemon`: passed after review follow-up.
+- `./gradlew check build --no-daemon`: passed after review follow-up. Docker image build was skipped by the existing harness because Docker is not available locally.

--- a/src/test/java/com/wedit/backend/config/LocalConfigContractTest.java
+++ b/src/test/java/com/wedit/backend/config/LocalConfigContractTest.java
@@ -41,7 +41,8 @@ class LocalConfigContractTest {
 
         assertTrue(localConfig.contains("${LOCAL_DB_URL:"));
         assertTrue(localConfig.contains("${LOCAL_DB_USERNAME:"));
-        assertTrue(localConfig.contains("${LOCAL_DB_PASSWORD:"));
+        assertTrue(localConfig.contains("${LOCAL_DB_PASSWORD:}"));
+        assertFalse(localConfig.contains("ohw62459930"));
     }
 
     private static Properties loadLocalConfig() {

--- a/src/test/java/com/wedit/backend/config/LocalConfigContractTest.java
+++ b/src/test/java/com/wedit/backend/config/LocalConfigContractTest.java
@@ -1,0 +1,64 @@
+package com.wedit.backend.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.io.FileSystemResource;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+class LocalConfigContractTest {
+
+    private static final Path LOCAL_CONFIG = Path.of("config/src/main/resources/application-local.yml");
+
+    @Test
+    void localProfileDefinesMysqlDatasource() {
+        Properties properties = loadLocalConfig();
+
+        assertTrue(properties.getProperty("spring.datasource.url").startsWith("${LOCAL_DB_URL:jdbc:mysql://localhost:3306/wedit"));
+        assertEquals("${LOCAL_DB_USERNAME:root}", properties.getProperty("spring.datasource.username"));
+        assertEquals("com.mysql.cj.jdbc.Driver", properties.getProperty("spring.datasource.driver-class-name"));
+    }
+
+    @Test
+    void localDatasourcePropertiesArePresent() {
+        Properties properties = loadLocalConfig();
+
+        assertRequiredProperty(properties, "spring.datasource.url");
+        assertRequiredProperty(properties, "spring.datasource.username");
+        assertRequiredProperty(properties, "spring.datasource.password");
+        assertRequiredProperty(properties, "spring.datasource.driver-class-name");
+    }
+
+    @Test
+    void localDatasourceCanBeOverriddenByEnvironment() throws Exception {
+        String localConfig = Files.readString(LOCAL_CONFIG);
+
+        assertTrue(localConfig.contains("${LOCAL_DB_URL:"));
+        assertTrue(localConfig.contains("${LOCAL_DB_USERNAME:"));
+        assertTrue(localConfig.contains("${LOCAL_DB_PASSWORD:"));
+    }
+
+    private static Properties loadLocalConfig() {
+        assertTrue(Files.exists(LOCAL_CONFIG), "application-local.yml must exist in the config submodule");
+
+        YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+        factory.setResources(new FileSystemResource(LOCAL_CONFIG));
+        Properties properties = factory.getObject();
+
+        assertTrue(properties != null, "application-local.yml must be readable as YAML properties");
+        return properties;
+    }
+
+    private static void assertRequiredProperty(Properties properties, String key) {
+        String value = properties.getProperty(key);
+
+        assertTrue(value != null, key + " must be configured");
+        assertFalse(value.isBlank(), key + " must not be blank");
+    }
+}

--- a/src/test/java/com/wedit/backend/config/LocalConfigContractTest.java
+++ b/src/test/java/com/wedit/backend/config/LocalConfigContractTest.java
@@ -15,13 +15,18 @@ import java.util.Properties;
 class LocalConfigContractTest {
 
     private static final Path LOCAL_CONFIG = Path.of("config/src/main/resources/application-local.yml");
+    private static final String LOCAL_DB_URL = "jdbc:mysql://localhost:3306/wedit?"
+            + "serverTimezone=Asia/Seoul&characterEncoding=UTF-8&sessionVariables="
+            + "sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
 
     @Test
     void localProfileDefinesMysqlDatasource() {
         Properties properties = loadLocalConfig();
 
-        assertTrue(properties.getProperty("spring.datasource.url").startsWith("${LOCAL_DB_URL:jdbc:mysql://localhost:3306/wedit"));
+        assertEquals("${LOCAL_DB_URL:" + LOCAL_DB_URL + "}", properties.getProperty("spring.datasource.url"));
         assertEquals("${LOCAL_DB_USERNAME:root}", properties.getProperty("spring.datasource.username"));
+        assertEquals("${LOCAL_DB_PASSWORD:}", properties.getProperty("spring.datasource.password"));
+        assertFalse(properties.getProperty("spring.datasource.password").contains("ohw62459930"));
         assertEquals("com.mysql.cj.jdbc.Driver", properties.getProperty("spring.datasource.driver-class-name"));
     }
 
@@ -33,16 +38,6 @@ class LocalConfigContractTest {
         assertRequiredProperty(properties, "spring.datasource.username");
         assertRequiredProperty(properties, "spring.datasource.password");
         assertRequiredProperty(properties, "spring.datasource.driver-class-name");
-    }
-
-    @Test
-    void localDatasourceCanBeOverriddenByEnvironment() throws Exception {
-        String localConfig = Files.readString(LOCAL_CONFIG);
-
-        assertTrue(localConfig.contains("${LOCAL_DB_URL:"));
-        assertTrue(localConfig.contains("${LOCAL_DB_USERNAME:"));
-        assertTrue(localConfig.contains("${LOCAL_DB_PASSWORD:}"));
-        assertFalse(localConfig.contains("ohw62459930"));
     }
 
     private static Properties loadLocalConfig() {


### PR DESCRIPTION
Closes #17

## Issue
- #17
- https://github.com/wedit-official/wedit-backend/issues/17

## EXEC_PLAN
- `docs/exec-plans/active/20260428-local-config-datasource.md`

## Verification
- Status: `passed`
- Command: `./gradlew check build --no-daemon`
- At: `2026-04-28T08:41:33+0900`

## Review Gate
- [ ] Automated PR review has completed.
- [ ] Every actionable PR review comment/thread is addressed and resolved.
- [ ] `scripts/task/verify-pr-ready.sh <PR_NUMBER>` passes before merge.
